### PR TITLE
Change VALUE_OPTIONAL to VALUE_NONE for generic option in make command

### DIFF
--- a/src/FilterMakeCommand.php
+++ b/src/FilterMakeCommand.php
@@ -75,7 +75,7 @@ class FilterMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['generic', 'g', InputOption::VALUE_OPTIONAL, 'Indicates if the generated filter should be generic.'],
+            ['generic', 'g', InputOption::VALUE_NONE, 'Indicates if the generated filter should be generic.'],
         ];
     }
 }


### PR DESCRIPTION
This fixes a bug with the generic option.