### PR TITLE
Allow configurable "in" separators

### DIFF
--- a/config/filterable.php
+++ b/config/filterable.php
@@ -36,7 +36,7 @@ return [
             '!='  => ['case' => 'where', 'operator' => '!=', 'template' => null],
             '='   => ['case' => 'where', 'operator' => '=', 'template' => null],
         ],
-        // accepts comma separated list
+        // accepts comma separated list, by default
         'in'        => [
             'i='  => ['case' => 'whereIn', 'operator' => null, 'template' => 'where-in'],
             'i=!' => ['case' => 'whereNotIn', 'operator' => null, 'template' => 'where-in'],
@@ -55,4 +55,7 @@ return [
     'default_grouping_operator' => 'and',
 
     'uri_grouping_operator' => 'grouping-operator',
+    
+     //The separator used for "in" filters in the querystring
+    'in_separator' => ',',
 ];

--- a/config/filterable.php
+++ b/config/filterable.php
@@ -56,6 +56,6 @@ return [
 
     'uri_grouping_operator' => 'grouping-operator',
     
-     //The separator used for "in" filters in the querystring
+     // the separator used for "in" filters in the query string
     'in_separator' => ',',
 ];

--- a/src/Generic/Templater.php
+++ b/src/Generic/Templater.php
@@ -113,6 +113,6 @@ class Templater
 
     protected function whereIn($value)
     {
-        return explode(',', $value);
+        return explode(config('filterable.in_separator', ','), $value);
     }
 }


### PR DESCRIPTION
Thanks for the great package!

I have a requirement to do "in" filtering that uses strings that may have commas in, so i'd like to make the separator a different character that isn't likely to be found in these strings, like `|`